### PR TITLE
Process command arguments should be inserted as array.

### DIFF
--- a/src/GlobalConfig.php
+++ b/src/GlobalConfig.php
@@ -159,10 +159,12 @@ class GlobalConfig {
       $commands[] = 'composer config --global ' . escapeshellcmd($config);
     }
     if ($commands) {
-      $process = new Process($commands);
-      $process->run();
-      if ($process->getExitCode()) {
-        throw new InvalidArgumentException("Problems settings global composer config with commands: " . $command);
+      foreach ($commands as $command) {
+        $process = new Process(explode(' ', $command));
+        $process->run();
+        if ($process->getExitCode()) {
+          throw new InvalidArgumentException("Problems settings global composer config with commands: " . $command);
+        }
       }
     }
   }


### PR DESCRIPTION
`phapp create` was running the command `exec 'composer config --global repositories.drunomics composer https://packages.drunomics.com'` which failed. I figured it was due to phapp inserting the command with all arguments as a single string, while symfony's process expects it to be an array of arguments.